### PR TITLE
Upgrade to selenium 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # selenium-api
 
-Additional Servlets and monitoring for Selenium Grid 2
+Additional Servlets and monitoring for Selenium Grid 3
 
 ## JSON console
 
@@ -11,6 +11,11 @@ regular console as JSON (and adds some extra infos).
 
 ```bash
 java -cp selenium-standalone<version>.jar:selenium-api.jar org.openqa.grid.selenium.GridLauncherV3 \
+-servlets com.xing.qa.selenium.grid.hub.Console -role hub
+```
+For windows users:
+```bash
+java -cp selenium-standalone<version>.jar;selenium-api.jar org.openqa.grid.selenium.GridLauncherV3 \
 -servlets com.xing.qa.selenium.grid.hub.Console -role hub
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-version = '0.7.0'
+version = '0.8.0'
 group = 'com.xing.qa'
 
 sourceCompatibility = 1.8
@@ -16,7 +16,7 @@ configurations {
 }
 
 dependencies {
-    provided 'org.seleniumhq.selenium:selenium-server:3.11.0'
+    provided 'org.seleniumhq.selenium:selenium-server:3.14.0'
     compile 'org.json:json:20080701'
     testCompile 'org.testng:testng:6.8.8'
 }

--- a/src/main/java/com/xing/qa/selenium/grid/hub/ConfigurableCapabilityMatcher.java
+++ b/src/main/java/com/xing/qa/selenium/grid/hub/ConfigurableCapabilityMatcher.java
@@ -2,7 +2,6 @@ package com.xing.qa.selenium.grid.hub;
 
 import com.xing.qa.selenium.grid.hub.capmat.CapMat;
 import com.xing.qa.selenium.grid.hub.capmat.ExactMatcher;
-
 import org.openqa.grid.internal.utils.CapabilityMatcher;
 import org.openqa.selenium.remote.CapabilityType;
 
@@ -25,7 +24,7 @@ public class ConfigurableCapabilityMatcher implements CapabilityMatcher {
 
     private static final Logger LOGGER = Logger.getLogger(ConfigurableCapabilityMatcher.class.getName());
 
-    private static final String DEFAULT_CAPABILITIES = CapabilityType.PLATFORM + ":platform," + CapabilityType.BROWSER_NAME + ":exact," + CapabilityType.VERSION + ":rvm";
+    private static final String DEFAULT_CAPABILITIES = CapabilityType.PLATFORM_NAME + ":platform," + CapabilityType.BROWSER_NAME + ":exact," + CapabilityType.VERSION + ":rvm";
     private static final String GRID_TOKEN = "_";
 
     private static final Pattern MEH = Pattern.compile("|\\*|[Aa][Nn][Yy]");

--- a/src/main/java/com/xing/qa/selenium/grid/hub/Console.java
+++ b/src/main/java/com/xing/qa/selenium/grid/hub/Console.java
@@ -6,21 +6,22 @@ import org.openqa.grid.internal.GridRegistry;
 import org.openqa.grid.internal.RemoteProxy;
 import org.openqa.grid.web.Hub;
 import org.openqa.grid.web.servlet.RegistryBasedServlet;
+import org.openqa.selenium.BuildInfo;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.internal.BuildInfo;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Writer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Console information nad more as JSON
+ * Console information and more as JSON
  *
  * @author Jens Hausherr (jens.hausherr@xing.com)
  */
@@ -41,7 +42,7 @@ public class Console extends RegistryBasedServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         try {
             if ("/requests".equals(req.getPathInfo())) {
                 sendJson(pendingRequests(), req, resp);
@@ -70,7 +71,7 @@ public class Console extends RegistryBasedServlet {
         resp.setContentType("application/json");
         resp.setCharacterEncoding("UTF-8");
         resp.setStatus(200);
-        Writer w = null;
+        Writer w;
         try {
             w = resp.getWriter();
             jo.write(w);
@@ -87,7 +88,7 @@ public class Console extends RegistryBasedServlet {
         List<Map<String,?>> desired;
 
         if (p > 0) {
-            desired = new ArrayList<Map<String, ?>>();
+            desired = new ArrayList<>();
             for (Capabilities c: getRegistry().getDesiredCapabilities()) {
                 desired.add(c.asMap());
             }
@@ -102,28 +103,28 @@ public class Console extends RegistryBasedServlet {
     }
 
     protected JSONObject status()
-            throws JSONException {
-            JSONObject status = new JSONObject();
+        throws JSONException {
+        JSONObject status = new JSONObject();
 
-            Hub h = getRegistry().getHub();
+        Hub h = getRegistry().getHub();
 
-            List<JSONObject> nodes = new ArrayList<JSONObject>();
+        List<JSONObject> nodes = new ArrayList<>();
 
-            for (RemoteProxy proxy : getRegistry().getAllProxies()) {
-                try {
-                    JSONRenderer beta = new WebProxyJsonRenderer(proxy);
-                    nodes.add(beta.render());
-                } catch (Exception e) {}
-            }
+        for (RemoteProxy proxy : getRegistry().getAllProxies()) {
+            try {
+                JSONRenderer beta = new WebProxyJsonRenderer(proxy);
+                nodes.add(beta.render());
+            } catch (Exception e) {}
+        }
 
-            status.put("version", coreVersion);
-            status.put("configuration", getRegistry().getHub().getConfiguration().toJson().getAsJsonObject().entrySet());
-            status.put("host", h.getConfiguration().host);
-            status.put("port", h.getConfiguration().port);
-            status.put("registration_url", h.getRegistrationURL());
-            status.put("nodes", nodes);
-            status.put("requests", pendingRequests());
+        status.put("version", coreVersion);
+        status.put("configuration", getRegistry().getHub().getConfiguration().toJson().entrySet());
+        status.put("host", h.getConfiguration().host);
+        status.put("port", h.getConfiguration().port);
+        status.put("registration_url", h.getRegistrationURL());
+        status.put("nodes", nodes);
+        status.put("requests", pendingRequests());
 
-            return status;
+        return status;
     }
 }


### PR DESCRIPTION
Hi,
I changed your code so it will now work with Selenium 3.14.
It now uses the proxy.getProxyStatus(); instead of proxy.getStatus(); which was deprecated since Selenium 3.10.
So I believe my changes will be backwards compatible untill version 3.10 of Selenium.

I also changed the browsername to not contain any spaces anymore.
By doing so it is easier to use an absolute json path in Jenkins for example.

Best Regards,

Richard 